### PR TITLE
feat: Add pet-room page

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -53,9 +53,7 @@ export const checkConsecutiveAttendance = async (
   }
 };
 
-export const getUserLevel = async (
-  userEmail: string,
-): Promise<number | null> => {
+export const getUserLevel = async (userEmail: string): Promise<number> => {
   if (!userEmail.trim()) throw new Error('이메일을 입력해주세요.');
   try {
     const { data } = await request.get<{ level: number }>(

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -52,3 +52,17 @@ export const checkConsecutiveAttendance = async (
     throw handleApiError(error, '연속 출석 체크');
   }
 };
+
+export const getUserLevel = async (
+  userEmail: string,
+): Promise<number | null> => {
+  if (!userEmail.trim()) throw new Error('이메일을 입력해주세요.');
+  try {
+    const { data } = await request.get<{ level: number }>(
+      API.USER.LEVEL(userEmail),
+    );
+    return data.level;
+  } catch (error) {
+    throw handleApiError(error, '레벨 조회');
+  }
+};

--- a/src/app/pet-room/page.tsx
+++ b/src/app/pet-room/page.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState, useMemo, Suspense } from 'react';
+import { rooms } from '@utils/rooms';
+import SplineScene from '@components/SplineScene';
+import dynamic from 'next/dynamic';
+import { getUserLevel } from '@api/user';
+import useUserStore from '@stores/userStore';
+
+const Spline = dynamic(() => import('@splinetool/react-spline'), {
+  ssr: false,
+  loading: () => <div>Loading...</div>,
+});
+
+export default function PetRoom() {
+  const { email } = useUserStore();
+  const [level, setLevel] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchLevel = async () => {
+      if (!email) return;
+      try {
+        const userLevel = await getUserLevel(email);
+        setLevel(userLevel ?? 1);
+      } catch (err) {
+        console.error('레벨 불러오기 실패:', err);
+        setLevel(1);
+      }
+    };
+    fetchLevel();
+  }, [email]);
+
+  const renderItems = useMemo(() => {
+    if (level === null || level === 10) return <p>추후 업데이트 예정</p>;
+
+    return [
+      <SplineScene key="item1" level={level} type="item" />,
+      (level === 6 || [4, 5, 7].includes(level)) && (
+        <SplineScene key="item2" level={level} type="item2" />
+      ),
+      level === 6 && <SplineScene key="item3" level={level} type="item3" />,
+    ].filter(Boolean);
+  }, [level]);
+
+  if (level === null) {
+    return <div className="text-center mt-10">레벨 정보를 불러오는 중...</div>;
+  }
+
+  return (
+    <div className="flex h-[90vh] w-full overflow-hidden flex-row items-center justify-between ml-0 md:ml-[290px] md:w-[calc(100vw-290px)]">
+      <div className="flex-1 w-full h-full min-w-[300px] min-h-[300px]">
+        <Suspense fallback={<div>Loading...</div>}>
+          <Spline scene={rooms[level - 1]} />
+        </Suspense>
+      </div>
+      <div className="w-[250px] p-2">
+        <div className="border-[5px] border-gray-300 rounded-[50px] flex flex-col items-center text-center m-2 p-2">
+          <p>다음 레벨 아이템</p>
+          <p>Lv. {level + 1}</p>
+          {renderItems}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SplineScene.tsx
+++ b/src/components/SplineScene.tsx
@@ -20,9 +20,16 @@ const SplineScene: React.FC<SplineSceneProps> = ({ level, type }) => {
         console.error('레벨은 0보다 커야 합니다');
         return '';
       }
-      if (type === 'item2') return items.item2[level - 4];
-      else if (type === 'item3') return items.item3[level - 6];
-      return items[type][level - 1];
+      const idx =
+        type === 'item2' ? level - 4 : type === 'item3' ? level - 6 : level - 1;
+      const scene = items[type][idx];
+      if (!scene) {
+        console.warn(
+          `레벨(${level})과 타입(${type})에 해당하는 씬이 없습니다.`,
+        );
+        return '';
+      }
+      return scene;
     } catch (error) {
       console.error('장면을 가져오는 중 오류 발생:', error);
       return '';

--- a/src/components/SplineScene.tsx
+++ b/src/components/SplineScene.tsx
@@ -1,0 +1,42 @@
+import React, { lazy, Suspense } from 'react';
+import { items } from '@utils/items';
+
+interface Items {
+  item: string[];
+  item2: string[];
+  item3: string[];
+}
+interface SplineSceneProps {
+  level: number;
+  type: keyof Items;
+}
+
+const Spline = lazy(() => import('@splinetool/react-spline'));
+
+const SplineScene: React.FC<SplineSceneProps> = ({ level, type }) => {
+  const getScene = (level: number, type: keyof Items): string => {
+    try {
+      if (level <= 0) {
+        console.error('레벨은 0보다 커야 합니다');
+        return '';
+      }
+      if (type === 'item2') return items.item2[level - 4];
+      else if (type === 'item3') return items.item3[level - 6];
+      return items[type][level - 1];
+    } catch (error) {
+      console.error('장면을 가져오는 중 오류 발생:', error);
+      return '';
+    }
+  };
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Spline
+        style={{ width: '80%', height: '180px' }}
+        scene={getScene(level, type)}
+      />
+    </Suspense>
+  );
+};
+
+export default SplineScene;

--- a/src/utils/endPoint.ts
+++ b/src/utils/endPoint.ts
@@ -13,6 +13,7 @@ export const API = {
     ATTEND: '/users/attend',
     CHECK_ATTEND: (userEmail: string) =>
       `/users/attend/${encodeURIComponent(userEmail)}`,
+    LEVEL: (email: string) => `/users/level/${email}`,
   },
   OPENAI: {
     GET_ALGORITHM_COURSE: '/openai/recommendation',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 사용자의 레벨에 따라 3D 씬과 아이템을 동적으로 보여주는 펫룸 페이지가 추가되었습니다.
    - 3D 씬을 렌더링하는 새로운 컴포넌트가 도입되어, 각 레벨 및 아이템 종류별로 맞춤형 씬을 제공합니다.
    - 사용자 이메일을 기반으로 레벨 정보를 불러오는 기능이 추가되었습니다.
    - 사용자 레벨 정보를 조회하는 API 엔드포인트가 추가되었습니다.

- **버그 수정**
    - 잘못된 이메일 입력 및 데이터 요청 실패 시 적절한 오류 메시지와 기본 레벨(1)로 대체하는 처리가 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->